### PR TITLE
[12.0][IMP] base_edi: introduce a basic edi user group

### DIFF
--- a/base_edi/__manifest__.py
+++ b/base_edi/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Base EDI",
     "summary": """Base module to aggregate EDI features.""",
     "version": "12.0.1.0.1",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "license": "LGPL-3",
     'website': 'https://github.com/OCA/edi',
     "author": "ACSONE,Odoo Community Association (OCA)",

--- a/base_edi/security/edi_groups.xml
+++ b/base_edi/security/edi_groups.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="group_edi_user" model="res.groups">
+        <field name="name">EDI User</field>
+        <field name="category_id" ref="module_category_edi" />
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
     <record id="group_edi_manager" model="res.groups">
         <field name="name">EDI Manager</field>
         <field name="category_id" ref="module_category_edi" />
@@ -7,5 +17,6 @@
             name="users"
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
         />
+        <field name="implied_ids" eval="[(4, ref('base_edi.group_edi_user'))]" />
     </record>
 </odoo>


### PR DESCRIPTION
### Context
- The **edi_oca** module, currently in **beta**, depends on the **base_edi** module, which had a **development status** of **alpha**. This caused a warning during testing. A recent commit (OCA@e5db4e0) has updated **base_edi** to **beta**.
- Additionally, a basic EDI user group is needed for managing access.

### Changes
- The development status of **base_edi** has been changed from **alpha** to **beta**.
- Introduced a basic EDI user group for better access control.